### PR TITLE
Include the full hide wine exports implementation.

### DIFF
--- a/wine/hidewineexports.patch
+++ b/wine/hidewineexports.patch
@@ -1,16 +1,133 @@
 diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
-index 011e868..c9c7c84 100644
+index 6b089c990b5..b3927deab89 100644
 --- a/dlls/ntdll/loader.c
 +++ b/dlls/ntdll/loader.c
-@@ -2440,7 +2442,6 @@ static void build_ntdll_module(void)
-     node_ntdll = wm->ldr.DdagNode;
-     if (TRACE_ON(relay)) RELAY_SetupDLL( module );
+@@ -87,6 +87,9 @@ static const WCHAR system_dir[] = L"C:\\windows\\system32\\";
+ /* system search path */
+ static const WCHAR system_path[] = L"C:\\windows\\system32;C:\\windows\\system;C:\\windows";
  
--    hidden_exports_init( wm->ldr.FullDllName.Buffer );
++#define IS_OPTION_TRUE(ch) ((ch) == 'y' || (ch) == 'Y' || (ch) == 't' || (ch) == 'T' || (ch) == '1')
++
++
+ static BOOL is_prefix_bootstrap;  /* are we bootstrapping the prefix? */
+ static BOOL imports_fixup_done = FALSE;  /* set once the imports have been fixed up, before attaching them */
+ static BOOL process_detaching = FALSE;  /* set on process detach to avoid deadlocks with thread detach */
+@@ -107,6 +110,8 @@ struct dll_dir_entry
+ 
+ static struct list dll_dir_list = LIST_INIT( dll_dir_list );  /* extra dirs from LdrAddDllDirectory */
+ 
++static BOOL hide_wine_exports = FALSE;  /* try to hide ntdll wine exports from applications */
++
+ struct ldr_notification
+ {
+     struct list                    entry;
+@@ -2052,6 +2057,96 @@ NTSTATUS WINAPI LdrUnlockLoaderLock( ULONG flags, ULONG_PTR magic )
  }
  
  
-@@ -2991,6 +2992,7 @@ static WINE_MODREF *build_main_module(void)
++/***********************************************************************
++ *           hidden_exports_init
++ *
++ * Initializes the hide_wine_exports options.
++ */
++static void hidden_exports_init( const WCHAR *appname )
++{
++    static const WCHAR configW[] = {'S','o','f','t','w','a','r','e','\\','W','i','n','e',0};
++    static const WCHAR appdefaultsW[] = {'A','p','p','D','e','f','a','u','l','t','s','\\',0};
++    static const WCHAR hideWineExports[] = {'H','i','d','e','W','i','n','e','E','x','p','o','r','t','s',0};
++    OBJECT_ATTRIBUTES attr;
++    UNICODE_STRING nameW;
++    HANDLE root, config_key, hkey;
++    BOOL got_hide_wine_exports = FALSE;
++    char tmp[80];
++    DWORD dummy;
++
++    RtlOpenCurrentUser( KEY_ALL_ACCESS, &root );
++    attr.Length = sizeof(attr);
++    attr.RootDirectory = root;
++    attr.ObjectName = &nameW;
++    attr.Attributes = OBJ_CASE_INSENSITIVE;
++    attr.SecurityDescriptor = NULL;
++    attr.SecurityQualityOfService = NULL;
++    RtlInitUnicodeString( &nameW, configW );
++
++    /* @@ Wine registry key: HKCU\Software\Wine */
++    if (NtOpenKey( &config_key, KEY_QUERY_VALUE, &attr )) config_key = 0;
++    NtClose( root );
++    if (!config_key) return;
++
++    if (appname && *appname)
++    {
++        const WCHAR *p;
++        WCHAR appversion[MAX_PATH+20];
++
++        if ((p = wcsrchr( appname, '/' ))) appname = p + 1;
++        if ((p = wcsrchr( appname, '\\' ))) appname = p + 1;
++
++        wcscpy( appversion, appdefaultsW );
++        wcscat( appversion, appname );
++        RtlInitUnicodeString( &nameW, appversion );
++        attr.RootDirectory = config_key;
++
++        /* @@ Wine registry key: HKCU\Software\Wine\AppDefaults\app.exe */
++        if (!NtOpenKey( &hkey, KEY_QUERY_VALUE, &attr ))
++        {
++            TRACE( "getting HideWineExports from %s\n", debugstr_w(appversion) );
++
++            RtlInitUnicodeString( &nameW, hideWineExports );
++            if (!NtQueryValueKey( hkey, &nameW, KeyValuePartialInformation, tmp, sizeof(tmp), &dummy ))
++            {
++                WCHAR *str = (WCHAR *)((KEY_VALUE_PARTIAL_INFORMATION *)tmp)->Data;
++                hide_wine_exports = IS_OPTION_TRUE( str[0] );
++                got_hide_wine_exports = TRUE;
++            }
++
++            NtClose( hkey );
++        }
++    }
++
++    if (!got_hide_wine_exports)
++    {
++        TRACE( "getting default HideWineExports\n" );
++
++        RtlInitUnicodeString( &nameW, hideWineExports );
++        if (!NtQueryValueKey( config_key, &nameW, KeyValuePartialInformation, tmp, sizeof(tmp), &dummy ))
++        {
++            WCHAR *str = (WCHAR *)((KEY_VALUE_PARTIAL_INFORMATION *)tmp)->Data;
++            hide_wine_exports = IS_OPTION_TRUE( str[0] );
++        }
++    }
++
++    NtClose( config_key );
++}
++
++
++/***********************************************************************
++ *           is_hidden_export
++ *
++ * Checks if a specific export should be hidden.
++ */
++static BOOL is_hidden_export( void *proc )
++{
++    return hide_wine_exports && (proc == &wine_get_version ||
++                                 proc == &wine_get_build_id ||
++                                 proc == &wine_get_host_version);
++}
++
++
+ /******************************************************************
+  *		LdrGetProcedureAddress  (NTDLL.@)
+  */
+@@ -2072,7 +2167,7 @@ NTSTATUS WINAPI LdrGetProcedureAddress(HMODULE module, const ANSI_STRING *name,
+     {
+         void *proc = name ? find_named_export( module, exports, exp_size, name->Buffer, -1, NULL, wm, TRUE )
+                           : find_ordinal_export( module, exports, exp_size, ord - exports->Base, NULL, wm, TRUE );
+-        if (proc)
++        if (proc && !is_hidden_export( proc ))
+         {
+             *address = proc;
+             ret = STATUS_SUCCESS;
+@@ -2893,6 +2988,7 @@ static WINE_MODREF *build_main_module(void)
      if (status) goto failed;
      RtlFreeUnicodeString( &nt_name );
      wm->ldr.LoadCount = -1;
@@ -18,3 +135,19 @@ index 011e868..c9c7c84 100644
      return wm;
  failed:
      MESSAGE( "wine: failed to create main module for %s, status %lx\n",
+diff --git a/dlls/ntdll/ntdll_misc.h b/dlls/ntdll/ntdll_misc.h
+index 99e0aceeef3..d392518d4f3 100644
+--- a/dlls/ntdll/ntdll_misc.h
++++ b/dlls/ntdll/ntdll_misc.h
+@@ -114,6 +114,11 @@ static inline void *get_rva( HMODULE module, DWORD va )
+     return (void *)((char *)module + va);
+ }
+ 
++/* version */
++extern const char * CDECL wine_get_version(void);
++extern const char * CDECL wine_get_build_id(void);
++extern void CDECL wine_get_host_version( const char **sysname, const char **release );
++
+ /* convert from straight ASCII to Unicode without depending on the current codepage */
+ static inline void ascii_to_unicode( WCHAR *dst, const char *src, size_t len )
+ {


### PR DESCRIPTION
This allows the patch to be applied to vanilla wine, without needing to apply wine-staging first.