### PR TITLE
Rebase some Wine patches to work with Valve Wine (and Proton by extension)

### DIFF
--- a/proton/cache-committed-size.patch
+++ b/proton/cache-committed-size.patch
@@ -1,0 +1,73 @@
+From f5301fa7f5559484cd94456ff56e2bfaa4778f8b Mon Sep 17 00:00:00 2001
+From: Jack Greiner <jack@emoss.org>
+Date: Wed, 21 Jan 2026 15:34:13 -0500
+Subject: [PATCH] ntdll: Cache memory info to improve performance.
+
+This improves the speed of get_committed_size which assists in Star Citizen in loading correctly with various debugging bits enabled.
+---
+ dlls/ntdll/unix/virtual.c | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 7378c967a5d..acd051d607e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -240,6 +240,10 @@ struct file_view
+     void         *base;          /* base address */
+     size_t        size;          /* size in bytes */
+     unsigned int  protect;       /* protection for all pages at allocation time and SEC_* flags */
++    SIZE_T        last_committed_size;
++    void         *last_query_base;
++    unsigned long long last_commit_size_check;
++    BYTE          first_page_vprot;
+ };
+ 
+ /* per-page protection flags */
+@@ -1965,6 +1969,8 @@ static NTSTATUS create_view( struct file_view **view_ret, void *base, size_t siz
+     view->base    = base;
+     view->size    = size;
+     view->protect = vprot;
++    view->last_commit_size_check = 0;
++    view->last_query_base = NULL;
+     set_page_vprot( base, size, vprot );
+ 
+     register_view( view );
+@@ -5797,6 +5803,12 @@ static struct file_view *get_memory_region_size( char *base, char **region_start
+     return NULL;
+ }
+ 
++static unsigned long long get_current_millis(void)
++{
++    struct timespec cur_time;
++    clock_gettime(CLOCK_MONOTONIC, &cur_time);
++    return cur_time.tv_sec * 1000 + (cur_time.tv_nsec / 1000000);
++}
+ 
+ static unsigned int fill_basic_memory_info( const void *addr, MEMORY_BASIC_INFORMATION *info )
+ {
+@@ -5843,7 +5855,21 @@ static unsigned int fill_basic_memory_info( const void *addr, MEMORY_BASIC_INFOR
+         BYTE vprot;
+ 
+         info->AllocationBase = alloc_base;
+-        info->RegionSize = get_committed_size( view, base, ~(size_t)0, &vprot, ~VPROT_WRITEWATCH );
++        if (get_current_millis() - view->last_commit_size_check < 4 &&
++            base >= (char *)view->last_query_base &&
++            base < (char *)view->last_query_base + view->last_committed_size)
++        {
++            info->RegionSize = view->last_committed_size - (base - (char *)view->last_query_base);
++            vprot = view->first_page_vprot;
++        }
++        else
++        {
++            info->RegionSize = get_committed_size( view, base, ~(size_t)0, &vprot, ~VPROT_WRITEWATCH );
++            view->last_committed_size = info->RegionSize;
++            view->last_query_base = base;
++            view->first_page_vprot = vprot;
++            view->last_commit_size_check = get_current_millis();
++        }
+         info->State = (vprot & VPROT_COMMITTED) ? MEM_COMMIT : MEM_RESERVE;
+         info->Protect = (vprot & VPROT_COMMITTED) ? get_win32_prot( vprot, view->protect ) : 0;
+         info->AllocationProtect = get_win32_prot( view->protect, view->protect );
+-- 
+2.52.0
+

--- a/proton/sc_gpumem.patch
+++ b/proton/sc_gpumem.patch
@@ -1,0 +1,168 @@
+From 93d7924f62c6a8600cb85cba2f9eecf127babb98 Mon Sep 17 00:00:00 2001
+From: Jack Greiner <jack@emoss.org>
+Date: Wed, 21 Jan 2026 15:49:37 -0500
+Subject: [PATCH] win32u: Minimal D3DKMT query implementation for Star Citizen.
+
+Implement a minimal version of NtGdiDdDDIQueryAdapterInfo (NODEMETADATA)
+and NtGdiDdDDIQueryStatistics to return GPU memory statistics.
+
+This is required for Star Citizen's performance monitoring and potentially other features to function correctly.
+
+Includes a short-lived cache to minimize overhead on repetitive queries.
+---
+ dlls/win32u/d3dkmt.c | 126 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 126 insertions(+)
+
+diff --git a/dlls/win32u/d3dkmt.c b/dlls/win32u/d3dkmt.c
+index 74dbce9539f..d037b04891d 100644
+--- a/dlls/win32u/d3dkmt.c
++++ b/dlls/win32u/d3dkmt.c
+@@ -365,6 +365,20 @@ NTSTATUS WINAPI NtGdiDdDDIQueryAdapterInfo( D3DKMT_QUERYADAPTERINFO *desc )
+ 
+             status = STATUS_SUCCESS;
+         }
++        else if (desc->Type == KMTQAITYPE_NODEMETADATA)
++        {
++            UINT *node = desc->pPrivateDriverData;
++
++            if (desc->PrivateDriverDataSize < sizeof(*node) * 2)
++                status = STATUS_INVALID_PARAMETER;
++            else
++            {
++                memset( node, 0, desc->PrivateDriverDataSize );
++                /* NodeData.EngineType = DXGK_ENGINE_TYPE_3D */
++                node[1] = 1;
++                status = STATUS_SUCCESS;
++            }
++        }
+         else
+         {
+             FIXME("desc %p, type %d stub\n", desc, desc->Type);
+@@ -374,12 +388,124 @@ NTSTATUS WINAPI NtGdiDdDDIQueryAdapterInfo( D3DKMT_QUERYADAPTERINFO *desc )
+     return status;
+ }
+ 
++static __thread struct {
++    LUID AdapterLuid;
++    DWORD time;
++    ULONGLONG total[2];
++    ULONGLONG budget[2];
++    ULONGLONG usage[2];
++} g_GPUMemCache = {0};
++
++static inline ULONGLONG GPUMem( LUID AdapterLuid, ULONGLONG *budget, ULONGLONG *usage, BOOL shared )
++{
++    DWORD now = NtGetTickCount();
++    BOOL use_cache = FALSE;
++    int idx_target = shared ? 1 : 0;
++
++    if (g_GPUMemCache.AdapterLuid.LowPart == AdapterLuid.LowPart && g_GPUMemCache.AdapterLuid.HighPart == AdapterLuid.HighPart)
++        if (now - g_GPUMemCache.time < 123)
++            use_cache = TRUE;
++
++    if (!use_cache)
++    {
++        D3DKMT_OPENADAPTERFROMLUID adp = { .AdapterLuid = AdapterLuid };
++        struct d3dkmt_adapter *adapter;
++
++        g_GPUMemCache.AdapterLuid = AdapterLuid;
++        g_GPUMemCache.time = now;
++        g_GPUMemCache.total[0] = g_GPUMemCache.total[1] = 0;
++        g_GPUMemCache.budget[0] = g_GPUMemCache.budget[1] = 0;
++        g_GPUMemCache.usage[0] = g_GPUMemCache.usage[1] = 0;
++
++        if (NtGdiDdDDIOpenAdapterFromLuid( &adp ) == STATUS_SUCCESS)
++        {
++            pthread_mutex_lock( &d3dkmt_lock );
++            if ((adapter = find_adapter_from_handle( adp.hAdapter )) && adapter->vk_device)
++            {
++                VkPhysicalDeviceMemoryBudgetPropertiesEXT mem_budget = {0};
++                VkPhysicalDeviceMemoryProperties2 properties2 = {0};
++
++                mem_budget.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT;
++                properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
++                properties2.pNext = &mem_budget;
++
++                pvkGetPhysicalDeviceMemoryProperties2KHR( adapter->vk_device, &properties2 );
++                for (UINT i = 0; i < properties2.memoryProperties.memoryHeapCount; ++i)
++                {
++                    int idx = (properties2.memoryProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) ? 0 : 1;
++                    ULONGLONG s = properties2.memoryProperties.memoryHeaps[i].size;
++                    ULONGLONG b = min( s, mem_budget.heapBudget[i] );
++                    ULONGLONG u = min( b, mem_budget.heapUsage[i] );
++                    g_GPUMemCache.total[idx] += s;
++                    g_GPUMemCache.budget[idx] += b;
++                    g_GPUMemCache.usage[idx] += u;
++                }
++            }
++            pthread_mutex_unlock( &d3dkmt_lock );
++            NtGdiDdDDICloseAdapter( &(D3DKMT_CLOSEADAPTER){ .hAdapter = adp.hAdapter } );
++        }
++    }
++
++    if (budget) *budget = g_GPUMemCache.budget[idx_target];
++    if (usage) *usage = g_GPUMemCache.usage[idx_target];
++    return g_GPUMemCache.total[idx_target];
++}
++
+ /******************************************************************************
+  *           NtGdiDdDDIQueryStatistics    (win32u.@)
+  */
+ NTSTATUS WINAPI NtGdiDdDDIQueryStatistics( D3DKMT_QUERYSTATISTICS *stats )
+ {
+     FIXME( "(%p): stub\n", stats );
++
++    switch ((int)stats->Type)
++    {
++    case D3DKMT_QUERYSTATISTICS_ADAPTER:
++    {
++        D3DKMT_OPENADAPTERFROMLUID adp = { .AdapterLuid = stats->AdapterLuid };
++        memset( &stats->QueryResult, 0, sizeof(stats->QueryResult) );
++        if (NtGdiDdDDIOpenAdapterFromLuid( &adp ) == STATUS_SUCCESS)
++        {
++            stats->QueryResult.AdapterInformation.NbSegments = 2;
++            stats->QueryResult.AdapterInformation.NodeCount = 1;
++            g_GPUMemCache.AdapterLuid.LowPart = g_GPUMemCache.AdapterLuid.HighPart = 0;
++            NtGdiDdDDICloseAdapter( &(D3DKMT_CLOSEADAPTER){ .hAdapter = adp.hAdapter } );
++        }
++        break;
++    }
++    case D3DKMT_QUERYSTATISTICS_SEGMENT:
++    case D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT:
++    case 0x09 /* D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP */:
++    {
++        ULONGLONG total, budget, usage;
++        ULONG aperture = !!stats->QueryProcessSegment.SegmentId;
++
++        memset( &stats->QueryResult, 0, sizeof(stats->QueryResult) );
++        if (stats->QuerySegment.SegmentId > 1) break;
++        if (stats->Type >= D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT)
++            if (stats->hProcess && stats->hProcess != GetCurrentProcess())
++                break;
++
++        if ((total = GPUMem( stats->AdapterLuid, &budget, &usage, aperture )) > 0)
++        {
++            if (stats->Type == D3DKMT_QUERYSTATISTICS_SEGMENT) {
++                stats->QueryResult.SegmentInformation.CommitLimit = total;
++                stats->QueryResult.SegmentInformation.BytesCommitted = total - budget + usage;
++                stats->QueryResult.SegmentInformation.BytesResident = stats->QueryResult.SegmentInformation.BytesCommitted;
++                stats->QueryResult.SegmentInformation.Aperture = aperture;
++            } else if (stats->Type == D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT) {
++                stats->QueryResult.ProcessSegmentInformation.BytesCommitted = usage;
++            } else {
++                /* ProcessSegmentGroupInformation.Budget */
++                stats->QueryResult.ProcessSegmentInformation.BytesCommitted = budget;
++                /* ProcessSegmentGroupInformation.Usage */
++                stats->QueryResult.ProcessSegmentInformation.MinimumWorkingSet = usage;
++            }
++        }
++        break;
++    }
++    }
++
+     return STATUS_SUCCESS;
+ }
+ 
+-- 
+2.52.0
+


### PR DESCRIPTION
In my adventures to get a Proton build that includes all of the LUG patches the Wine builds do, I needed to rebase these two patches to work.

Both apply properly and are functional when applied to a bleeding-edge Valve Wine build.

sc_gpumem.patch in particular is quite different in how it's code is hit due to differences in how much of D3DKMT is implemented, but still works as intended.