### PR TITLE
Some little changes and pointer warping.

### DIFF
--- a/wine/systray-title.patch
+++ b/wine/systray-title.patch
@@ -1,0 +1,14 @@
+Gives the little systray window a title.
+diff --git a/programs/explorer/systray.c b/programs/explorer/systray.c
+index fcbceb6..0e5ece3 100644
+--- a/programs/explorer/systray.c
++++ b/programs/explorer/systray.c
+@@ -1253,7 +1253,7 @@ void initialize_systray( BOOL arg_using_root, BOOL arg_enable_shell, BOOL arg_sh
+     else
+     {
+         SIZE size = get_window_size();
+-        tray_window = CreateWindowExW( 0, shell_traywnd_class.lpszClassName, L"", WS_CAPTION | WS_SYSMENU,
++        tray_window = CreateWindowExW( 0, shell_traywnd_class.lpszClassName, L"Wine System Tray", WS_CAPTION | WS_SYSMENU,
+                                        CW_USEDEFAULT, CW_USEDEFAULT, size.cx, size.cy, 0, 0, 0, 0 );
+         NtUserMessageCall( tray_window, WINE_SYSTRAY_DOCK_INIT, 0, 0, NULL, NtUserSystemTrayCall, FALSE );
+     }

--- a/wine/unopenable-device-is-bad.patch
+++ b/wine/unopenable-device-is-bad.patch
@@ -12,8 +12,8 @@ index a189472..070bbb8 100644
 +            /* HACK: if user can not open this file, maybe pretend it's a bad device type */
 +            if (unopenable_device_is_bad == -1)
 +            {
-+                char *env = getenv("WINE_UNOPENABLE_DEVICE_IS_BAD");
-+                unopenable_device_is_bad = env ? atoi(env) : 0;
++                char *env = getenv("WINE_UNOPENABLE_DEVICE_IS_NOT_BAD");
++                unopenable_device_is_bad = env ? !atoi(env) : 1;
 +            }
 +            if (unopenable_device_is_bad != 0 && access(*unix_name, R_OK))
 +                return STATUS_BAD_DEVICE_TYPE;

--- a/wine/winewayland-guess-primary-output.patch
+++ b/wine/winewayland-guess-primary-output.patch
@@ -1,0 +1,55 @@
+Try to guess the primary output on Wayland.
+diff --git a/dlls/winewayland.drv/display.c b/dlls/winewayland.drv/display.c
+index b2a9428..5a1946b 100644
+--- a/dlls/winewayland.drv/display.c
++++ b/dlls/winewayland.drv/display.c
+@@ -269,9 +269,11 @@ static void wayland_add_device_modes(const struct gdi_device_manager *device_man
+ UINT WAYLAND_UpdateDisplayDevices(const struct gdi_device_manager *device_manager, void *param)
+ {
+     struct wayland_output *output;
+-    DWORD state_flags = DISPLAY_DEVICE_ATTACHED_TO_DESKTOP | DISPLAY_DEVICE_PRIMARY_DEVICE;
++    DWORD state_flags;
+     struct wl_array output_info_array;
+     struct output_info *output_info;
++    struct output_info *primary_output_info = NULL;
++    char *primary_output_override = getenv("WAYLANDDRV_PRIMARY_MONITOR");
+ 
+     TRACE("\n");
+ 
+@@ -292,12 +294,35 @@ UINT WAYLAND_UpdateDisplayDevices(const struct gdi_device_manager *device_manage
+     /* Populate GDI devices. */
+     wayland_add_device_gpu(device_manager, param);
+ 
++    /* Guess the primary output. */
+     wl_array_for_each(output_info, &output_info_array)
+     {
++        /* If an override is provided, use that. */
++        if (primary_output_override && strcmp(primary_output_override, output_info->output->name) == 0)
++        {
++            primary_output_info = output_info;
++            break;
++        }
++        if (primary_output_info == NULL)
++        {
++            primary_output_info = output_info;
++            continue;
++        }
++        /* Assume the output with the widest resolution is the primary. */
++        if (output_info->output->current_mode->width > primary_output_info->output->current_mode->width ||
++            (output_info->output->current_mode->width == primary_output_info->output->current_mode->width &&
++            output_info->output->current_mode->height > primary_output_info->output->current_mode->height))
++            primary_output_info = output_info;
++    }
++
++    wl_array_for_each(output_info, &output_info_array)
++    {
++        state_flags = DISPLAY_DEVICE_ATTACHED_TO_DESKTOP;
++        if (output_info == primary_output_info)
++            state_flags |= DISPLAY_DEVICE_PRIMARY_DEVICE;
+         wayland_add_device_source(device_manager, param, state_flags, output_info);
+         wayland_add_device_monitor(device_manager, param, output_info);
+         wayland_add_device_modes(device_manager, param, output_info);
+-        state_flags &= ~DISPLAY_DEVICE_PRIMARY_DEVICE;
+     }
+ 
+     wl_array_release(&output_info_array);

--- a/wine/winewayland-prefer-relative-pointer.patch
+++ b/wine/winewayland-prefer-relative-pointer.patch
@@ -1,0 +1,140 @@
+Once you go relative you never go back.
+Makes mousing around in Star Citizen not do crazy mouse movements.
+Does mean the cursor position can be offset if the window resizes without losing focus.
+But that can be fixed by unfocusing and focusing the window.
+Also confines the pointer if it's unconfined and a warp was requested.
+diff --git a/dlls/winewayland.drv/wayland_pointer.c b/dlls/winewayland.drv/wayland_pointer.c
+index 109dd2d..c3194c9 100644
+--- a/dlls/winewayland.drv/wayland_pointer.c
++++ b/dlls/winewayland.drv/wayland_pointer.c
+@@ -893,7 +893,7 @@ static void wayland_pointer_update_constraint(struct wl_surface *wl_surface,
+     needs_lock = wl_surface &&
+                  (((confine_rect || covers_vscreen) && !is_visible) || force_lock) &&
+                  pointer->wl_pointer;
+-    needs_confine = wl_surface && confine_rect && is_visible && !force_lock &&
++    needs_confine = wl_surface && (confine_rect || pointer->pending_warp) && is_visible && !force_lock &&
+                     pointer->wl_pointer;
+ 
+     if (!needs_confine && pointer->zwp_confined_pointer_v1)
+@@ -915,12 +915,15 @@ static void wayland_pointer_update_constraint(struct wl_surface *wl_surface,
+     if (needs_confine)
+     {
+         HWND hwnd = wl_surface_get_user_data(wl_surface);
+-        struct wl_region *region;
++        struct wl_region *region = NULL;
+ 
+-        region = wl_compositor_create_region(process_wayland.wl_compositor);
+-        wl_region_add(region, confine_rect->left, confine_rect->top,
+-                      confine_rect->right - confine_rect->left,
+-                      confine_rect->bottom - confine_rect->top);
++        if (confine_rect)
++        {
++            region = wl_compositor_create_region(process_wayland.wl_compositor);
++            wl_region_add(region, confine_rect->left, confine_rect->top,
++                        confine_rect->right - confine_rect->left,
++                        confine_rect->bottom - confine_rect->top);
++        }
+ 
+         if (!pointer->zwp_confined_pointer_v1 || pointer->constraint_hwnd != hwnd)
+         {
+@@ -940,14 +943,20 @@ static void wayland_pointer_update_constraint(struct wl_surface *wl_surface,
+             zwp_confined_pointer_v1_set_region(pointer->zwp_confined_pointer_v1,
+                                                region);
+         }
++        if (confine_rect)
++        {
++            TRACE("Confining to hwnd=%p wayland=%d,%d+%d,%d\n",
++                pointer->constraint_hwnd,
++                confine_rect->left, confine_rect->top,
++                confine_rect->right - confine_rect->left,
++                confine_rect->bottom - confine_rect->top);
++        }
++        else
++        {
++            TRACE("Confining to hwnd=%p due to warp\n", pointer->constraint_hwnd);
++        }
+ 
+-        TRACE("Confining to hwnd=%p wayland=%d,%d+%d,%d\n",
+-              pointer->constraint_hwnd,
+-              confine_rect->left, confine_rect->top,
+-              confine_rect->right - confine_rect->left,
+-              confine_rect->bottom - confine_rect->top);
+-
+-        wl_region_destroy(region);
++        if (region) wl_region_destroy(region);
+     }
+     else if (needs_lock)
+     {
+@@ -990,12 +999,6 @@ static void wayland_pointer_update_constraint(struct wl_surface *wl_surface,
+                                              &relative_pointer_v1_listener, NULL);
+         TRACE("Enabling relative motion\n");
+     }
+-    else if (!needs_relative && pointer->zwp_relative_pointer_v1)
+-    {
+-        zwp_relative_pointer_v1_destroy(pointer->zwp_relative_pointer_v1);
+-        pointer->zwp_relative_pointer_v1 = NULL;
+-        TRACE("Disabling relative motion\n");
+-    }
+ }
+ 
+ void wayland_pointer_clear_constraint(void)
+@@ -1021,11 +1024,6 @@ BOOL WAYLAND_SetCursorPos(INT x, INT y)
+     struct wayland_pointer *pointer = &process_wayland.pointer;
+ 
+     pthread_mutex_lock(&pointer->mutex);
+-    if (pointer->zwp_relative_pointer_v1)
+-    {
+-        pthread_mutex_unlock(&pointer->mutex);
+-        return FALSE;
+-    }
+     pointer->pending_warp = TRUE;
+     pthread_mutex_unlock(&pointer->mutex);
+ 
+@@ -1072,21 +1070,29 @@ BOOL WAYLAND_ClipCursor(const RECT *clip, BOOL reset)
+     {
+         if (process_wayland.wp_pointer_warp_v1)
+         {
+-            wp_pointer_warp_v1_warp_pointer(
+-                    process_wayland.wp_pointer_warp_v1,
+-                    wl_surface,
+-                    pointer->wl_pointer,
+-                    wl_fixed_from_int(warp_x),
+-                    wl_fixed_from_int(warp_y),
+-                    pointer->enter_serial);
+-            TRACE("warp_pointer hwnd=%p wayland_xy=%d,%d screen_xy=%d,%d\n",
+-                    hwnd, warp_x, warp_y, cursor_pos.x, cursor_pos.y);
++            if (!(hwnd == pointer->constraint_hwnd && pointer->zwp_locked_pointer_v1))
++            {
++                wp_pointer_warp_v1_warp_pointer(
++                        process_wayland.wp_pointer_warp_v1,
++                        wl_surface,
++                        pointer->wl_pointer,
++                        wl_fixed_from_int(warp_x),
++                        wl_fixed_from_int(warp_y),
++                        pointer->enter_serial);
++                TRACE("warp_pointer hwnd=%p wayland_xy=%d,%d screen_xy=%d,%d\n",
++                        hwnd, warp_x, warp_y, cursor_pos.x, cursor_pos.y);
++                if (pointer->zwp_confined_pointer_v1)
++                {
++                    pointer->pending_warp = FALSE;
++                    pthread_mutex_unlock(&pointer->mutex);
++                    return TRUE;
++                }
++            }
+         }
+         else
+         {
+             wayland_pointer_update_constraint(wl_surface, NULL, FALSE, TRUE);
+         }
+-        pointer->pending_warp = FALSE;
+     }
+ 
+     if (wl_surface && hwnd == pointer->constraint_hwnd && pointer->zwp_locked_pointer_v1)
+@@ -1112,6 +1118,7 @@ BOOL WAYLAND_ClipCursor(const RECT *clip, BOOL reset)
+                                       (clip && wl_surface) ? &confine_rect : NULL,
+                                       covers_vscreen,
+                                       FALSE);
++    pointer->pending_warp = FALSE;
+     pthread_mutex_unlock(&pointer->mutex);
+ 
+     wl_display_flush(process_wayland.wl_display);


### PR DESCRIPTION
Here it is.

I updated unopenable-device-is-bad.patch to be on by default. I have been using it like this for months without problems and this should make things easier for those who just have to change the library folder for whatever reason.

Systray title just makes it easier to see what exactly that little window with the RSI icon is.

For winewayland there is guessing the primary output. This _replaces_ the current patches for picking a primary monitor by doing it in a slightly different way. It also as the name implies tries to guess the primary output so should make things easier for people. I do not know how well it actually works in practice though so might be best to keep it in an experimental build?

And finally there is the prefer relative pointer patch for winewayland. This makes the game fully playable (at least from my testing...) with winewayland with the hardware cursor enabled. It warps exactly as it should and does not jerk the view around.
There are just two minor things issues with it. First is that when unfocusing and focusing the game it jerks the view a bit to the bottom right. The second is that when the game window is resized the cursor position is offset and wrong, but this is is fixed by simply unfocusing and refocusing the game. The game window is only resized when changing resolution so it's an acceptable compromise for now.

Oh and as a bonus it applies a pointer confinement on a warp if there isn't one. I can only make the pointer escape the window if I really move it fast while entering interaction mode.

I tested on KWin, GNOME and niri, worked on all of them.